### PR TITLE
Fix to allow users to click the same city

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,6 @@ function App() {
   Analytics.pageview('/');
 
   const [mapValue, setMapValue] = React.useState('');
-
   // Initialize the app theming.
   useTheming();
 
@@ -24,7 +23,11 @@ function App() {
 
   return (
     <div className="app">
-      <Sidebar incidents={incidents} mapValue={mapValue} />
+      <Sidebar
+        incidents={incidents}
+        mapValue={mapValue}
+        setMapValue={setMapValue}
+      />
       <Map incidents={incidents} onCityClick={setMapValue} />
       <Footer />
     </div>

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -18,10 +18,6 @@ const containerStyle = {
 };
 
 const options = {
-  center: {
-    lat: 38,
-    lng: -98,
-  },
   restriction: {
     latLngBounds: {
       north: 52,
@@ -41,6 +37,10 @@ function Map({ incidents, onCityClick }) {
 
   const onLoad = React.useCallback(function callback(mapInstance) {
     setMap(mapInstance);
+    mapInstance.setCenter({
+      lat: 38,
+      lng: -98,
+    });
   }, []);
 
   function handleMapClick(e) {

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -41,6 +41,7 @@ function Map({ incidents, onCityClick }) {
       lat: 38,
       lng: -98,
     });
+    mapInstance.setZoom(5);
   }, []);
 
   function handleMapClick(e) {
@@ -71,7 +72,6 @@ function Map({ incidents, onCityClick }) {
           options,
           styles: theme === 'dark' ? mapDarkTheme : null,
         }}
-        zoom={5}
         onLoad={onLoad}
         onClick={handleMapClick}
       >

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -11,14 +11,17 @@ const fuse = new Fuse([], {
   keys: ['city', 'state', 'title'],
 });
 
-function Sidebar({ incidents, mapValue }) {
+function Sidebar({ incidents, mapValue, setMapValue }) {
   const [search, setSearch] = React.useState('');
 
   React.useEffect(() => {
     setSearch(mapValue);
   }, [mapValue]);
 
-  const handleClear = () => setSearch('');
+  const handleClear = () => {
+    setSearch('');
+    setMapValue('');
+  };
   const isOpen = !!search;
 
   // Inform the Fuse instance of the new `incidents` array
@@ -51,6 +54,7 @@ function Sidebar({ incidents, mapValue }) {
 Sidebar.propTypes = {
   incidents: PropTypes.arrayOf(PropTypes.object).isRequired,
   mapValue: PropTypes.string.isRequired,
+  setMapValue: PropTypes.func.isRequired,
 };
 
 export default Sidebar;


### PR DESCRIPTION
ref #41 

## ✏️ Proposed Changes
- Set center only on load to prevent center from switching after clicking "X" on Omnibox
- This also allows us to set the order to be either
```
    Analytics.event('Map', 'Clicked on a city', city.name);
    onCityClick(city.name);

    map.setZoom(7);
    map.panTo({
      lat: Number(city.coordinate.lat),
      lng: Number(city.coordinate.long),
    });
```

```
    map.setZoom(7);
    map.panTo({
      lat: Number(city.coordinate.lat),
      lng: Number(city.coordinate.long),
    });
    Analytics.event('Map', 'Clicked on a city', city.name);
    onCityClick(city.name);
```

## 💥 Type of change
<!-- remove ones that don't apply -->
- Bug fix (non-breaking change which fixes an issue)

## 📝 QA Checklist

### General
- design looks good and is responsive
- firefox + chrome both looks good
- no other technical errors

### Steps
- Click on `Minneapolis`, click "X" on omnibox, click on `Minneapolis` again
Expect results to appear properly

## Screenshots
https://www.loom.com/share/be2c62504a0c470895edf8bcc8bcb108
