### PR TITLE
Move color definitions into a single file and clean up variable names.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import useIncidents from './hooks/getIncidents';
 import useTheming from './hooks/useTheming';
 
 import './App.css';
+import './constants/colors.css';
 
 function App() {
   // Start tracking pageviews/events

--- a/src/components/footer/footer.css
+++ b/src/components/footer/footer.css
@@ -10,7 +10,7 @@ footer {
     bottom: 0;
     opacity: 0.7;
     left: 50%;
-    background-color: rgb(228, 228, 228);
+    background-color: var(--footerPrimary);
     font-size: 15px;
     padding: 0 10px;
   }

--- a/src/components/omnibox/omnibox.css
+++ b/src/components/omnibox/omnibox.css
@@ -1,15 +1,3 @@
-:root {
-  --omnibox-background: #FFF;
-  --logo-color: #000;
-  --input-color: auto;
-}
-
-[data-theme="dark"] {  
-  --omnibox-background: #272727;
-  --logo-color: #FFF;
-  --input-color: #FFF;
-}
-
 .omnibox {
   position: absolute;
   left: 0;
@@ -21,8 +9,8 @@
   margin: 8px;
   border-radius: 8px;
 
-  background-color: var(--omnibox-background);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2), 0 -1px 0px rgba(0, 0, 0, 0.02);
+  background-color: var(--omniboxPrimary);
+  box-shadow: 0 2px 4px var(--transparentBlack), 0 -1px 0px var(--transparentBlack);
 
   z-index: 2;
 }
@@ -43,7 +31,7 @@
 
   font-size: 15px;
   font-weight: 500;
-  color: var(--input-color);
+  color: var(--inputPrimary);
 
   border: none;
   outline: none;
@@ -53,7 +41,7 @@
 }
 
 .omnibox form input::placeholder {
-  color: #bbbbbb;
+  color: var(--gray);
 }
 
 .omnibox form .icon {
@@ -64,22 +52,22 @@
 
   padding: 12px 15px;
 
-  color: #bbbbbb;
+  color: var(--gray);
   cursor: pointer;
 }
 
 .omnibox form .icon:hover,
 .omnibox form .icon.active {
-  color: #3771E0;
+  color: var(--blue);
 }
 
 .omnibox form .icon.logo {
-  color: var(--logo-color);
+  color: var(--logo);
 }
 
 .omnibox form .divider {
   width: 1px;
   height: 24px;
 
-  background-color: #dddddd;
+  background-color: var(--lightGrayPrimary);
 }

--- a/src/components/panel/panel.css
+++ b/src/components/panel/panel.css
@@ -1,11 +1,3 @@
-:root {
-  --panel-open-bg: var(--search-results-bg-color);
-}
-
-[data-theme="dark"] {
-  --panel-open-bg: var(--search-results-bg-color);
-}
- 
 .panel {
   display: flex;
   flex-direction: column;
@@ -13,8 +5,8 @@
   width: 408px;
   height: 100vh;
 
-  background-color: var(--panel-open-bg);
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.3);
+  background-color: var(--panelOpenBackground);
+  box-shadow: 0 0 20px var(--transparentBlack);
 
   z-index: 1;
 }

--- a/src/components/result-details/evidence.css
+++ b/src/components/result-details/evidence.css
@@ -1,13 +1,3 @@
-:root {
-  --evidence-title: #000;
-  --evidence-description: #70757A;
-}
-
-[data-theme="dark"] {
-  --evidence-title: #FFF;
-  --evidence-description: #A7A7A7;
-}
-
 .evidence {
   display: flex;
   flex-direction: column;
@@ -17,7 +7,7 @@
   margin: 24px 0 0 0;
   padding: 0 24px;
 
-  color: var(--evidence-title);
+  color: var(--evidenceTitle);
   font-size: 16px;
   font-weight: 500;
 }
@@ -26,6 +16,6 @@
   margin: 12px 0;
   padding: 0 24px;
 
-  color: var(--evidence-description);
+  color: var(--evidenceDescription);
   font-size: 13px;
 }

--- a/src/components/result-details/links.css
+++ b/src/components/result-details/links.css
@@ -1,11 +1,3 @@
-:root {
-  --icon-hover-bg: #F1F3F4;
-}
-
-[data-theme="dark"] {
-  --icon-hover-bg: #252525;
-}
-
 .links {
   display: flex;
   flex-wrap: wrap;
@@ -31,13 +23,13 @@
 
   padding: 8px;
 
-  color: #3771e0;
+  color: var(--blue);
   border-radius: 17px;
-  border: 1px solid #3771e0;
+  border: 1px solid var(--blue);
 }
 
 .links a:hover svg {
-  background-color: var(--icon-hover-bg);
+  background-color: var(--iconHoverBackground);
 }
 
 .links a span {
@@ -46,5 +38,5 @@
   font-size: 13px;
   font-weight: 400;
 
-  color: #3771e0;
+  color: var(--blue);
 }

--- a/src/components/result-details/result-details.css
+++ b/src/components/result-details/result-details.css
@@ -1,17 +1,3 @@
-:root {
-  --result-title: #000;
-  --result-date: #A7A7A7;
-  --arrow-left-icon: #BBB;
-  --arrow-left-icon-hover: #000;
-}
-
-[data-theme="dark"] {
-  --result-title: #FFF;
-  --result-date: #A7A7A7;
-  --arrow-left-icon: #FFF;
-  --arrow-left-icon-hover: #A7A7A7;
-}
-
 .result-details {
   flex: 1;
   
@@ -31,18 +17,18 @@
 
   padding: 24px;
 
-  color: var(--arrow-left-icon);
+  color: var(--arrowLeftIcon);
   cursor: pointer;
 }
 
 .result-details .header svg:hover {
-  color: var(--arrow-left-icon-hover);
+  color: var(--arrowLeftIconHover);
 }
 
 .result-details .header h3 {
   margin: 0;
 
-  color: var(--result-title);
+  color: var(--resultTitle);
   font-size: 22px;
   font-weight: 500;
 }
@@ -51,13 +37,13 @@
   margin: 0;
   padding-top: 8px;
 
-  color: var(--result-date);
+  color: var(--resultDate);
   font-size: 14px;
 }
 
 .result-details .divider {
   height: 1px;
-  background-color: #e6e6e6;
+  background-color: var(--resultDetailsDivider);
 }
 
 .results-details-loader {

--- a/src/components/result-details/video.css
+++ b/src/components/result-details/video.css
@@ -4,7 +4,7 @@
 
   padding: 24px;
 
-  border-bottom: 1px solid #e6e6e6;
+  border-bottom: 1px solid var(--lightGraySecondary);
 }
 
 .video a {
@@ -34,19 +34,19 @@
 }
 
 .video a .source .label {
-  color: #000000;
+  color: var(--black);
   font-size: 15px;
 }
 
 .video a .source .type {
-  color: #70757a;
+  color: var(--mediumGray);
   font-size: 14px;
 }
 
 .video > p {
   margin: 12px 0 0;
 
-  color: #000000;
+  color: var(--black);
   font-size: 14px;
 }
 

--- a/src/components/search-results/search-result.css
+++ b/src/components/search-results/search-result.css
@@ -1,11 +1,3 @@
-:root {
-  --search-result-onhover: #FAFAFA;
-}
-
-[data-theme="dark"] {
-  --search-result-onhover: #252525;
-}
-
 .search-result {
   display: flex;
   flex-direction: column;
@@ -14,9 +6,9 @@
   padding: 10px 18px 10px 24px;
 
   cursor: pointer;
-  border-bottom: 1px solid #e6e6e6;
+  border-bottom: 1px solid var(--lightGraySecondary);
 }
 
 .search-result:hover {
-  background-color: var(--search-result-onhover);
+  background-color: var(--searchResultHover);
 }

--- a/src/components/search-results/search-results.css
+++ b/src/components/search-results/search-results.css
@@ -1,20 +1,8 @@
-:root {
-  --search-results-bg-color: #FFF;
-  --result-text-color: #000;
-  --result-details-color: #70757A;
-}
-
-[data-theme="dark"] {
-  --search-results-bg-color: #1B1B1B;
-  --result-text-color: #FFF;
-  --result-details-color: #A7A7A7;
-}
-
 .search-results {
   overflow-y: auto;
   
-  background-color: var(--search-results-bg-color);
-  border-top: 1px solid #e6e6e6;
+  background-color: var(--searchResultsBackground);
+  border-top: 1px solid var(--lightGraySecondary);
 }
 
 .search-results.empty {
@@ -24,7 +12,7 @@
 .search-results h4 {
   margin: 0;
   
-  color: var(--result-text-color);
+  color: var(--searchResultText);
   font-size: 16px;
   font-weight: 500;
 }
@@ -32,7 +20,7 @@
 .search-results p {
   margin: 4px 0;
 
-  color: var(--result-details-color);
+  color: var(--searchResultDetailsText);
   font-size: 13px;
 }
 
@@ -41,7 +29,7 @@
 }
 
 .search-results a {
-  color: #3771E0;
+  color: var(--blue);
   font-size: 13px;
   text-decoration: none;
 }

--- a/src/constants/colors.css
+++ b/src/constants/colors.css
@@ -1,0 +1,102 @@
+:root {
+    /* Colors */
+    --black: #000000;
+    --white: #FFFFFF;
+    --offWhitePrimary: #FAFAFA;
+    --offWhiteSecondary: #F1F3F4;
+    --charcoalPrimary: #252525;
+    --charcoalSecondary: #1B1B1B;
+    --transparentBlack: rgba(0, 0, 0, 0.2);
+    --gray: #BBBBBB;
+    --mediumGray: #70757A;
+    --lightGrayPrimary: #DDDDDD;
+    --lightGraySecondary: #E6E6E6;
+    --blue: #3771E0;
+    --silver: #A7A7A7;
+
+    /* Global */
+    caret-color: auto;
+
+    /* Footer */
+    --footerPrimary: var(--lightGraySecondary);
+
+    /* Omnibox */
+    --omniboxPrimary: var(--white);
+    --logo: var(--black);
+    --inputPrimary: auto;
+
+    /* Panel */
+    --panelOpenBackground: var(--searchResultsBackground);
+    
+    /* Result Details */
+    --resultTitle: var(--black);
+    --resultDate: var(--silver);
+    --resultDetailsDivider: var(--lightGraySecondary);
+    --arrowLeftIcon: var(--gray);
+    --arrowLeftIconHover: var(--black);
+
+    /* Result Details - Evidence */
+    --evidenceTitle: var(--black);
+    --evidenceDescription: var(--mediumGray);
+
+    /* Result Details - Links */
+    --iconHoverBackground: var(--offWhiteSecondary);
+
+    /* Search Results */
+    --searchResultHover: var(--offWhitePrimary);
+    --searchResultText: var(--black);
+    --searchResultDetailsText: var(--mediumGray);
+    --searchResultsBackground: var(--white);
+}
+
+
+[data-theme="dark"] {
+    /* Colors */
+    --black: #000000;
+    --white: #FFFFFF;
+    --offWhitePrimary: #FAFAFA;
+    --offWhiteSecondary: #F1F3F4;
+    --charcoalPrimary: #252525;
+    --charcoalSecondary: #1B1B1B;
+    --transparentBlack: rgba(0, 0, 0, 0.2);
+    --gray: #BBBBBB;
+    --mediumGray: #70757A;
+    --lightGrayPrimary: #DDDDDD;
+    --lightGraySecondary: #E6E6E6;
+    --blue: #3771E0;
+    --silver: #A7A7A7;
+    
+    /* Global */
+    caret-color: var(--white);
+
+    /* Footer */
+    --footerPrimary: var(--lightGraySecondary);
+
+    /* Omnibox */
+    --omniboxPrimary: var(--charcoalPrimary);
+    --logo: var(--white);
+    --inputPrimary: var(--white);
+    
+    /* Panel */
+    --panelOpenBackground: var(--searchResultsBackground);
+
+    /* Result Details */
+    --resultTitle: var(--white);
+    --resultDate: var(--silver);
+    --resultDetailsDivider: var(--lightGraySecondary);
+    --arrowLeftIcon: var(--white);
+    --arrowLeftIconHover: var(--silver);
+
+    /* Result Details - Evidence */
+    --evidenceTitle: var(--white);
+    --evidenceDescription: var(--silver);
+
+    /* Result Details - Links */
+    --iconHoverBackground: var(--charcoalPrimary);
+    
+    /* Search Results */
+    --searchResultHover: var(--charcoalPrimary);
+    --searchResultText: var(--white);
+    --searchResultDetailsText: var(--silver);
+    --searchResultsBackground: var(--charcoalSecondary);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,3 @@
-:root {
-  caret-color: auto;
-}
-
-[data-theme="dark"] {
-  caret-color: #FFF;
-}
-
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
ref #46

## ✏️ Proposed Changes
- Consolidate colors and variables declared in the CSS into a single file.

## 💥 Type of change
- Refactor (no changes in functionality)

## 📝 QA Checklist

### General
- design looks good and is responsive
- firefox + chrome both looks good
- no other technical errors

----
## Notes
I moved all of the existing CSS variable definitions into a single file, renamed a few where it felt appropriate, and then created a new set of variables for the colors used across the project. In a few instances, I took extremely similar colors (ex: #252525 and #272727) and replaced the usages with one color. I also left the named variables in place and set their values to reference the color variables, but that intermediate layer of variables could be removed (leaving only direct references to the color variables) if there's a strong opinion about it.